### PR TITLE
Fix terminal width detection on Linux

### DIFF
--- a/claude_tui_components/utils.py
+++ b/claude_tui_components/utils.py
@@ -56,7 +56,7 @@ def get_terminal_cols():
             if len(parts) < 2:
                 break
             ppid, tty = parts[0], parts[1]
-            if tty not in ("??", ""):
+            if tty not in ("??", "?", ""):
                 fd = os.open(f"/dev/{tty}", os.O_RDONLY)
                 try:
                     res = fcntl.ioctl(fd, termios.TIOCGWINSZ, b"\x00" * 8)


### PR DESCRIPTION
## Summary

`get_terminal_cols()` walks the process tree looking for a parent with a TTY, but on Linux the no-TTY marker is `?`, not `??` like macOS. The walk stopped at the first process, tried to open `/dev/?`, failed silently, and fell back to 80 columns. This made `fit_parts()` drop most statusline components on every Linux system.

## Changes

- `claude_tui_components/utils.py`, added `"?"` to the TTY exclusion check so the parent-walk skips no-TTY processes on Linux

Fixes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal dimension detection with more robust TTY validation and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/slima4/claude-tui/pull/8)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->