### PR TITLE
ci: make release tap-PR failure self-recoverable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,15 @@ jobs:
         # peter-evans/create-pull-request handles branch create + commit + push +
         # PR open in one step. Auth uses the same PAT as checkout so the PR
         # author triggers the tap's CI workflow (test-formula.yml).
+        #
+        # HOMEBREW_TAP_TOKEN must be a fine-grained PAT scoped to
+        # slima4/homebrew-claude-tui with BOTH:
+        #   - Contents: Read and write       (push the bump branch)
+        #   - Pull requests: Read and write  (open the PR)
+        # A token with only Contents pushes the branch fine but fails PR
+        # creation with "Resource not accessible by personal access token".
+        id: tap_pr
+        continue-on-error: true
         uses: peter-evans/create-pull-request@v6
         with:
           path: tap
@@ -81,3 +90,33 @@ jobs:
 
             Tap CI will validate this bump on merge candidates. Review the diff,
             wait for the `Test formula` checks to go green, then merge.
+
+      - name: Surface manual recovery if PR step failed
+        # peter-evans pushes the bump branch before opening the PR, so a
+        # token-scope failure leaves a usable branch with the correct
+        # url/sha256. Fail the job loudly with the exact one-liner to finish
+        # the release by hand instead of forcing a re-diagnosis.
+        if: steps.tap_pr.outcome == 'failure'
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          BRANCH="bump-${TAG}"
+          {
+            echo "## Tap PR step failed"
+            echo
+            echo "The \`${BRANCH}\` branch was pushed to slima4/homebrew-claude-tui"
+            echo "with the correct url/sha256, but the PR could not be opened."
+            echo "Most likely cause: \`HOMEBREW_TAP_TOKEN\` is missing the"
+            echo "\`Pull requests: Read and write\` permission on the tap repo."
+            echo
+            echo "Finish the release manually:"
+            echo
+            echo '```'
+            echo "gh pr create --repo slima4/homebrew-claude-tui \\"
+            echo "  --base main --head ${BRANCH} \\"
+            echo "  --title \"claude-tui ${TAG}\" \\"
+            echo "  --body \"Automated formula bump for ${TAG}.\""
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "::error::Tap PR not opened. Branch ${BRANCH} pushed; open the PR manually (see job summary)."
+          exit 1


### PR DESCRIPTION
## Summary

`release.yml` pushes the `bump-vX.Y.Z` branch to the Homebrew tap *before* opening the PR. When `HOMEBREW_TAP_TOKEN` lacks **Pull requests: write** on the tap repo, the push succeeds but PR-open fails with an opaque `Resource not accessible by personal access token` buried in the step log — observed on the v0.8.4 release, forced a full manual re-diagnosis.

This PR does **not** fix the token (a GitHub secret, fixed in settings). It makes the failure cheap to recover from when it recurs.

## Changes

- Document the exact required PAT scopes (Contents + Pull requests, both write) at the token-use site
- Mark the PR step `continue-on-error` with an `id`
- Add a failure step that writes the precise manual `gh pr create` recovery command to the job summary and fails the job loudly

## Test

- YAML validated (`yaml.safe_load`)
- Failure path is the previously-observed v0.8.4 scenario; branch is already pushed by the time the failure step runs, so recovery is one copy-paste from the run summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release automation workflow with improved error handling and comprehensive diagnostic capabilities for Homebrew package distribution. When issues occur during this step, the workflow now provides detailed recovery instructions and maintains operational continuity, ensuring the overall release process continues despite individual step failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/slima4/claude-tui/pull/9)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->